### PR TITLE
Add option to ignore pending transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Provides a mechanism for downloading transactions from various financial institu
     --credentials=<file> \
     [--output-format=<format>] \
     [--output-dir=<path>] \
+    [--ignore-pending] \
     [--suppress-warnings=<tf>] \
     [--verbose]
 ```

--- a/plaid2qif/plaid2qif.py
+++ b/plaid2qif/plaid2qif.py
@@ -6,7 +6,7 @@ Download financial transactions from Plaid and convert to QIF files.
 Usage:
   plaid2qif save-access-token --institution=<name> --public-token=<token> --credentials=<file> [--verbose]
   plaid2qif list-accounts --institution=<name> --credentials=<file> [--verbose]
-  plaid2qif download --institution=<name> --account=<account-name> --account-type=<type> --account-id=<acct-id> --from=<from-date> --to=<to-date> --credentials=<file> [--output-format=<format>] [--output-dir=<path>] [--suppress-warnings=<tf>] [--verbose]
+  plaid2qif download --institution=<name> --account=<account-name> --account-type=<type> --account-id=<acct-id> --from=<from-date> --to=<to-date> --credentials=<file> [--output-format=<format>] [--output-dir=<path>] [--ignore-pending] [--suppress-warnings=<tf>] [--verbose]
   plaid2qif -h | --help
   plaid2qif --version
 
@@ -23,6 +23,7 @@ Options:
   --to=<to-date>            End of date range.
   --output-format=<format>  Output format either 'raw', 'csv' or 'qif'. [Default: qif]
   --output-dir=<path>       Location to output file to. (Default: output to stdout)
+  --ignore-pending          Ignore pending transactions.
   --suppress-warnings=<tf>  Suppress warnings about running in a development environment. [Default: True]
   --verbose                 Verbose logging output.
 """
@@ -40,7 +41,7 @@ CFG_DIR='./cfg'
 
 PLAID_ENV = 'development' ## sandbox', 'development', or 'production'
 
-def download(account, fromto, output, suppress_warnings, plaid_credentials):
+def download(account, fromto, output, ignore_pending, suppress_warnings, plaid_credentials):
   client = open_client(plaid_credentials, suppress_warnings)
   access_token = read_access_token(account['institution'])
   account_name = account['name']
@@ -67,6 +68,9 @@ def download(account, fromto, output, suppress_warnings, plaid_credentials):
     while  txn_batch > 0 and txn_batch <= txn_total:
       
       for t in response['transactions']:
+        if ignore_pending and t['pending']:
+          info('skipping pending transaction for [%s: %s]' % (t['date'], t['name']))
+          continue
         info('writing record for [%s: %s]' % (t['date'], t['name']))
         debug('%s' % t)
         w.write_record(t)
@@ -162,9 +166,10 @@ def main():
       'dir': args['--output-dir'],
       'format': args['--output-format']
     }
+    ignore_pending = args['--ignore-pending']
     suppress_warnings = args['--suppress-warnings']
     plaid_credentials = args['--credentials']
-    download(account, fromto, output, suppress_warnings, plaid_credentials)
+    download(account, fromto, output, ignore_pending, suppress_warnings, plaid_credentials)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
When pending transactions become final, they may have their amount, transaction
id, date, etc. re-stated. Some accounting import tools are not smart enough to
avoid duplicate entries that have to be manually pruned later.

This commit adds an option for users who are willing to sacrifice some
up-to-date data in order to avoid this problem entirely, by only looking at
final transactions.