### PR TITLE
pin versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-wheel
-twine
-docopt
-plaid-python
-python-dateutil
+wheel==0.33.1
+twine==1.13.0
+docopt==0.6.2
+plaid-python==2.4.1
+python-dateutil==2.8.0


### PR DESCRIPTION
I'm working with @simonmichael to run this over in #hledger at freenode but we've run into a couple hiccups. It seems plaid-python is shipping lots of updates lately https://pypi.org/project/plaid-python/#history - pinning to prevent any breakage.

I think  you'll need to cut a new release and update setup.py also, but not sure about those details. Looking into it but you'll know how to do that faster I believe..