### PR TITLE
auth.html: use "transactions" product instead of "auth"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ plaid2qif download \
     env: 'development',
     clientName: 'Plaid2QIF',
     key: '[PUBLIC_KEY]', // Replace with your public_key from plaid-credentials.json
-    product: 'auth',
+    product: 'transactions',
     apiVersion: 'v2',
     onLoad: function() {
       // The Link module finished loading.


### PR DESCRIPTION
At least one credit card company (American Express) is not an option when I use the "auth" product type and try to link the account. Since the goal is to retrieve transactions, it seems like this is the more correct product to pass to `Plaid.create`