### PR TITLE
Fix Client constructor for use on plaid-python 7.1.0 and plaid API version 2020-09-14

### DIFF
--- a/plaid2qif/plaid2qif.py
+++ b/plaid2qif/plaid2qif.py
@@ -46,8 +46,8 @@ def download(account, fromto, output, ignore_pending, suppress_warnings, plaid_c
   account_name = account['name']
   account_id = account['id']
 
-  response = client.Transactions.get(access_token, 
-    fromto['start'], fromto['end'], 
+  response = client.Transactions.get(access_token,
+    fromto['start'], fromto['end'],
     account_ids=[account_id])
 
   txn_batch = len(response['transactions'])
@@ -58,14 +58,14 @@ def download(account, fromto, output, ignore_pending, suppress_warnings, plaid_c
   output_file = '%s/%s' % (output['dir'], util.output_filename(account_name, fromto, output['format']))
 
   output_handle = output_to_file and open(output_file, 'w') or sys.stdout
-  
+
   try:
     w = transaction_writer.TransactionWriter.instance(output['format'], output_handle)
     w.begin(account)
 
     debug("txn cnt: %d, txn total: %d" % (txn_batch, txn_total))
     while  txn_batch > 0 and txn_batch <= txn_total:
-      
+
       for t in response['transactions']:
         if ignore_pending and t['pending']:
           info('skipping pending transaction for [%s: %s]' % (t['date'], t['name']))
@@ -74,8 +74,8 @@ def download(account, fromto, output, ignore_pending, suppress_warnings, plaid_c
         debug('%s' % t)
         w.write_record(t)
 
-      response = client.Transactions.get(access_token, 
-        start_date=fromto['start'], end_date=fromto['end'], 
+      response = client.Transactions.get(access_token,
+        start_date=fromto['start'], end_date=fromto['end'],
         offset=txn_sofar, account_ids=[account_id] )
 
       txn_batch = len(response['transactions'])
@@ -127,16 +127,16 @@ def open_client(plaid_credentials, suppress_warnings=True):
 
   debug('opening client for %s' % plaid_env)
   credentials = {}
-  
+
   info('reading credentials from file: %s' % plaid_credentials)
   with open(plaid_credentials) as json_data:
-      credentials = json.load(json_data)
+    credentials = json.load(json_data)
 
-  return plaid.Client(credentials['client_id'],
-                      credentials['secret'],
-                      credentials['public_key'],
-                      plaid_env,
-                      suppress_warnings)
+  return plaid.Client(
+    client_id=credentials['client_id'],
+    secret=credentials['secret'],
+    environment=plaid_env,
+    suppress_warnings=suppress_warnings)
 
 
 def main():


### PR DESCRIPTION
In the newer `plaid-python` library, the 3rd positional argument to the
`plaid.Client` constructor war removed [1], causing all of our other args to shift
and pass the token as the env, suppress warnings as the timeout, etc.

This updates the code to use kwargs instead, so that we don't depend on the
relative ordering in the class constructor. I've tested this successfully with
the versions listed in the subject line as part of packaging for NixPkgs [2]

With this commit, we can download new transactions with the latest libs and API,
which gives us most of the support for resolving #16 (just the docs/code on
creating new link tokens needs to be updated).

[1] https://github.com/plaid/plaid-python/blob/a0f7891dac304b6d8bee08ec4286fcaa8b5358f5/plaid/client.py#L39-L46
[2] https://github.com/NixOS/nixpkgs/pull/102368