### PR TITLE
Changes to support plaid-python 8.X.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Provides a mechanism for downloading transactions from various financial institu
     [--output-format=<format>] \
     [--output-dir=<path>] \
     [--ignore-pending] \
-    [--suppress-warnings=<tf>] \
     [--verbose]
 ```
 

--- a/plaid2qif/util.py
+++ b/plaid2qif/util.py
@@ -3,13 +3,8 @@ from logging import INFO, DEBUG, basicConfig
 
 
 def output_filename(account_path, fromto, file_ext):
-  def format_date(date):
-    d = parse(date)
-    return d.strftime('%Y-%m-%d')
-  fmt_start = format_date(fromto['start'])
-  fmt_end = format_date(fromto['end'])
   account = account_path.split(':')[-1]
-  return '%s--%s-%s.%s' % (fmt_start, fmt_end, account, file_ext)
+  return '%s--%s-%s.%s' % (fromto['start'], fromto['end'], account, file_ext)
 
 
 def configure_logging(level):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docopt
-plaid-python
+plaid-python >= 8.0.0
 python-dateutil


### PR DESCRIPTION
- APIs are now redesigned with typed calls, as described in
  https://plaid.com/docs/api/

- start_date and end_date must now be datetime types

- Environment is now a type instead of a string

- `suppress_warnings` appears to no longer be an option, but I also don't see it
  spewing warnings, so I've just removed it.

I have done a full set of end-to-end tests using this with my personal setup,
which includes many accounts, so I think I've covered all the necessary updates
with this PR.